### PR TITLE
CHAT-1894|fix firebase duplicate-app init error

### DIFF
--- a/test/experimental/firebase-service.spec.js
+++ b/test/experimental/firebase-service.spec.js
@@ -42,7 +42,7 @@ describe('NEW (experimental) firebase service', () => {
     expect(firebase.signInWithCustomToken).to.have.been.calledWith(authKey);
   });
 
-  it('should not re-initialize firebase if firebase app was already initialized and experiment is on ', async () => {
+  it('should not re-initialize firebase if firebase app was already initialized', async () => {
     firebaseService = new FirebaseService('firebase-service-uut');
 
     const options = {

--- a/test/experimental/firebase-service.spec.js
+++ b/test/experimental/firebase-service.spec.js
@@ -135,13 +135,20 @@ describe('NEW (experimental) firebase service', () => {
       });
   });
 
-  it('should not stay in initializing mode if the app wasn\'t initialized', async () => {
+  it('should re-initialize firebase if firebase failed to initialize the previous time', async () => {
+    firebaseService = new FirebaseService('firebase-service-uut');
+
     const expectedError = new Error('init fail mock');
     firebase.initializeApp = sinon.stub().returns(Promise.reject(expectedError));
 
     await callAndCatch(() => firebaseService.connect());
+    expect(firebase.initializeApp).to.have.been.called;
 
-    expect(firebaseService._initializing).to.equal(false);
+    firebase.initializeApp.reset();
+
+    await callAndCatch(() => firebaseService.connect());
+    expect(firebase.initializeApp).to.have.been.called;
+
   });
 
   it('should support listening on a ref', async () => {

--- a/test/experimental/firebase-service.spec.js
+++ b/test/experimental/firebase-service.spec.js
@@ -119,7 +119,6 @@ describe('NEW (experimental) firebase service', () => {
     });
   });
 
-
   it('should not initialize app more than once (should go-online, instead)', done => {
     firebaseService.connect()
       .then(() => {
@@ -134,12 +133,6 @@ describe('NEW (experimental) firebase service', () => {
       .catch(err => {
         done(err);
       });
-  });
-
-  it('should not initialize app more than once (should go-online, instead)', async () => {
-    firebaseService.connect();
-    await firebaseService.connect();
-    expect(firebase.initializeApp).to.have.been.calledOnce;
   });
 
   it('should not stay in initializing mode if the app wasn\'t initialized', async () => {


### PR DESCRIPTION
Should fix sporadic uh oh error that happens due to two (or more) firebase subscribe/connect invocations in the queue. This fix will make additional connect requests wait until the ongoing one is completed.
refs https://sentry.io/organizations/wix_o/issues/962215241/?project=84240