### PR TITLE
fix(firebase/app):use import instead of require

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 After writing the same code twice in different projects, I figured I should
  share it. It's nothing major, just a facade around the Firebase sdk.
+ 

--- a/src/experimental/firebase-service.js
+++ b/src/experimental/firebase-service.js
@@ -1,4 +1,5 @@
-let firebase;
+import firebase from 'firebase/app';
+
 let uuid;
 
 class FirebaseService {
@@ -7,7 +8,6 @@ class FirebaseService {
   constructor(name, { atomicServerTime = false } = {}) {
     uuid = require('uuid/v4');
     name = name || uuid();
-    firebase = require('firebase/app');
     require('firebase/database');
     require('firebase/auth');
     this.name = name;


### PR DESCRIPTION
after upgrading to `firebase@8` - using `firebase = require('firebase/app')` followed by `firebase.initializeApp` resulted in an error similar to the one mentioned here: https://github.com/firebase/firebaseui-web/issues/392#issuecomment-568479088

importing using es6 syntax should solve it

this is under a major version (`firebase-service@5`) so should not affect production - should test with `chat-sdk@21` (which uses `firebase-service@5`) and see if realtime works as expected
