### PR TITLE
firebase version updated to the latest -> 9.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "firebase-service",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "author": {
     "name": "Aaron Greenwald",
     "email": "aarong@wix.com",
@@ -20,7 +20,7 @@
     "prepush": "yoshi lint"
   },
   "dependencies": {
-    "firebase": "^8.0.0",
+    "firebase": "^9.18.0",
     "uuid": "^3.0.1",
     "sinon-chai": "^2.12.0"
   },


### PR DESCRIPTION
Inbox chat-sdk uses firebase-service, which uses an ancient firebase version (~8.0.0) that uses AsyncStorage directly from RN (a transitive dependency), which is removed in RN71.